### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ allprojects {
 	}
 	
 	dependencies {
-	        compile 'com.github.john990:WaveView:v0.9'
+	        implementation 'com.github.john990:WaveView:v0.9'
 	}
 ````


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.