### PR TITLE
feat: Fill to brim

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 WaveView
 ========
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/john990/WaveView?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/john990/WaveView?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-WaveView-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1260)
 
-A wave view of android,can be used as progress bar.
+A wave view for android, which can be used as progress bar.
 
 
 ### Screenshot
@@ -34,8 +34,9 @@ A wave view of android,can be used as progress bar.
         wave:blow_wave_color="@android:color/white"
         wave:progress="80"
         wave:wave_height="little"
-        wave:wave_hz="normal"
-        wave:wave_length="middle" />
+        wave:wave_hz="little"
+        wave:wave_length="middle" 
+        wave:fill_to_brim="true"/>
 ````
 or you can just use(default progress is 80%)
 ````xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
 }

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:wave="http://schemas.android.com/apk/res-auto"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <com.john.waveview.WaveView
         android:id="@+id/wave_view"
@@ -14,7 +14,8 @@
         wave:progress="80"
         wave:wave_height="little"
         wave:wave_hz="normal"
-        wave:wave_length="middle" />
+        wave:wave_length="middle"
+        wave:fill_to_brim="true"/>
 
     <SeekBar
         android:id="@+id/seek_bar"
@@ -24,4 +25,3 @@
         android:layout_marginBottom="20dp"
         android:progress="80" />
 </FrameLayout>
-

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -13,5 +14,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/library/src/main/java/com/john/waveview/Wave.java
+++ b/library/src/main/java/com/john/waveview/Wave.java
@@ -43,6 +43,8 @@ class Wave extends View {
     private float mMaxRight;
     private float mWaveHz;
 
+    private float mWaveMaxHeight;
+
     // wave animation
     private float mAboveOffset = 0.0f;
     private float mBlowOffset;
@@ -141,6 +143,14 @@ class Wave extends View {
                 return WAVE_HZ_SLOW;
         }
         return 0;
+    }
+
+    public float getMaxHeight(){
+        /* y = (float) (mWaveHeight * Math.sin(omega * x + mBlowOffset) + mWaveHeight);
+         * Max value of Math.sin(omega * x + mBlowOffset) = 1
+         * Hence, Max height = mWaveHeight * 1 + mWaveHeight
+         *                   = mWaveHeight * 2 */
+        return  mWaveHeight * 2;
     }
 
     /**

--- a/library/src/main/java/com/john/waveview/WaveView.java
+++ b/library/src/main/java/com/john/waveview/WaveView.java
@@ -44,7 +44,7 @@ public class WaveView extends LinearLayout {
         mProgress = attributes.getInt(R.styleable.WaveView_progress, DEFAULT_PROGRESS);
         mWaveHeight = attributes.getInt(R.styleable.WaveView_wave_height, MIDDLE);
         mWaveMultiple = attributes.getInt(R.styleable.WaveView_wave_length, LARGE);
-        mIsFilledTillBrim = attributes.getBoolean(R.styleable.WaveView_fill_to_brim,true);
+        mIsFilledTillBrim = attributes.getBoolean(R.styleable.WaveView_fill_to_brim,false);
         mWaveHz = attributes.getInt(R.styleable.WaveView_wave_hz, MIDDLE);
         attributes.recycle();
 

--- a/library/src/main/java/com/john/waveview/WaveView.java
+++ b/library/src/main/java/com/john/waveview/WaveView.java
@@ -28,6 +28,7 @@ public class WaveView extends LinearLayout {
 
     private Wave mWave;
     private Solid mSolid;
+    private boolean mIsFilledTillBrim;
 
     private final int DEFAULT_ABOVE_WAVE_COLOR = Color.WHITE;
     private final int DEFAULT_BLOW_WAVE_COLOR = Color.WHITE;
@@ -43,6 +44,7 @@ public class WaveView extends LinearLayout {
         mProgress = attributes.getInt(R.styleable.WaveView_progress, DEFAULT_PROGRESS);
         mWaveHeight = attributes.getInt(R.styleable.WaveView_wave_height, MIDDLE);
         mWaveMultiple = attributes.getInt(R.styleable.WaveView_wave_length, LARGE);
+        mIsFilledTillBrim = attributes.getBoolean(R.styleable.WaveView_fill_to_brim,true);
         mWaveHz = attributes.getInt(R.styleable.WaveView_wave_hz, MIDDLE);
         attributes.recycle();
 
@@ -76,7 +78,8 @@ public class WaveView extends LinearLayout {
     }
 
     private void computeWaveToTop() {
-        mWaveToTop = (int) (getHeight() * (1f - mProgress / 100f));
+        boolean isViewFilled = mProgress==100 && mIsFilledTillBrim;
+        mWaveToTop = (int)((isViewFilled)? (-mWave.getMaxHeight()) : (getHeight() * (1f - mProgress / 100f)));
         ViewGroup.LayoutParams params = mWave.getLayoutParams();
         if (params != null) {
             ((LayoutParams) params).topMargin = mWaveToTop;

--- a/library/src/main/res/values/attr.xml
+++ b/library/src/main/res/values/attr.xml
@@ -3,23 +3,30 @@
 
 	<declare-styleable name="WaveView">
 		<attr name="above_wave_color" format="color"/>
+
 		<attr name="blow_wave_color" format="color"/>
+
 		<attr name="progress" format="integer"/>
+
         <attr name="wave_length" format="enum">
             <enum name="large" value="1"/>
             <enum name="middle" value="2"/>
             <enum name="little" value="3"/>
         </attr>
+
         <attr name="wave_height" format="enum">
             <enum name="large" value="1"/>
             <enum name="middle" value="2"/>
             <enum name="little" value="3"/>
         </attr>
+
         <attr name="wave_hz" format="enum">
             <enum name="fast" value="1"/>
             <enum name="normal" value="2"/>
             <enum name="slow" value="3"/>
         </attr>
+
+        <attr name="fill_to_brim" format="boolean"/>
 	</declare-styleable>
 
 	<declare-styleable name="Themes">


### PR DESCRIPTION
- Allows users to let the view fill to the brim on their discretion via the newly created boolean attribute: `fill_to_brim`.

<p align="center">

<img src="https://user-images.githubusercontent.com/44941115/108624782-fed66a00-7481-11eb-94eb-0017e5303294.gif" width="25%" height="25%" /> 

<img src="https://user-images.githubusercontent.com/44941115/108624814-29282780-7482-11eb-822a-b2c8ca4ecbca.gif" width="25%" height="25%" /> 

</p>Users  alter this feature like this:    
    
```
. . .
wave:wave_length="middle"
wave:fill_to_brim="true" />
```

- Includes only  Gradle update and README Badge fix done in  #25. Note: It does not consider the feature implemented in #25. 

- README sample code update based on this feature.