### PR TITLE
feat: Wave color customisable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '20.0.0'
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 11
         targetSdkVersion 20
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation  project(':library')
 }

--- a/app/src/main/java/com/waveview/demo/MainActivity.java
+++ b/app/src/main/java/com/waveview/demo/MainActivity.java
@@ -1,6 +1,8 @@
 package com.waveview.demo;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
+import android.os.Build;
 import android.os.Bundle;
 import android.widget.SeekBar;
 
@@ -14,17 +16,27 @@ public class MainActivity extends Activity {
     private SeekBar seekBar;
     private WaveView waveView;
 
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
 
         seekBar = (SeekBar) findViewById(R.id.seek_bar);
         waveView = (WaveView) findViewById(R.id.wave_view);
+/*        final ArgbEvaluator evaluator = new ArgbEvaluator();
+        final int initColor = getResources().getColor(R.color.holo_red);
+        final int endColor = getResources().getColor(R.color.holo_green);*/
 
-        seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+
+
+      seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 waveView.setProgress(progress);
+             /* int color = (Integer) evaluator.evaluate(progress/100f,initColor,endColor);
+                waveView.setAboveWaveColor(color);
+                waveView.setBlowWaveColor(color);
+                waveView.setWaveColor(color);*/
             }
 
             @Override

--- a/app/src/main/res/drawable/gradient_background.xml
+++ b/app/src/main/res/drawable/gradient_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="@color/dark_blue"
+                android:endColor="@color/light_blue"
+                android:type="linear" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -8,13 +8,16 @@
         android:id="@+id/wave_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#ff702e8c"
-        wave:above_wave_color="@android:color/white"
-        wave:blow_wave_color="@android:color/white"
+        android:background="#FFFFFF"
+        wave:above_wave_color="@color/light_blue"
+        wave:blow_wave_color="@color/light_blue"
+        wave:above_wave_color_alpha="0.5"
+        wave:blow_wave_color_alpha="0.3"
         wave:progress="80"
-        wave:wave_height="little"
+        wave:wave_height="large"
         wave:wave_hz="normal"
-        wave:wave_length="middle" />
+        wave:wave_length="middle"
+        wave:background="@drawable/gradient_background"/>
 
     <SeekBar
         android:id="@+id/seek_bar"

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<color name="holo_purple">#ffaa66cc</color>
+	<color name="holo_green">#7CB342</color>
+	<color name="holo_red">#E53935</color>
+
+	<color name="light_blue">#DA00FFE1</color>
+	<color name="dark_blue">#007BFF</color>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -13,5 +14,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation  fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/library/src/main/java/com/john/waveview/Solid.java
+++ b/library/src/main/java/com/john/waveview/Solid.java
@@ -3,41 +3,78 @@ package com.john.waveview;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
+
+import static com.john.waveview.WaveView.alphaPercentToInt;
 
 /**
  * Created by John on 2014/10/15.
  */
 class Solid extends View {
 
-    private Paint aboveWavePaint;
-    private Paint blowWavePaint;
+    private final Paint mWavePaint = new Paint();
+    private int mWaveColor;
+    private float mWaveAlpha;
+    private Drawable mBackgroundDrawable;
 
-    public Solid(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+    private final Paint.Style STYLE = Paint.Style.FILL;
+
+    public Solid(Context context, SolidAttributes solidAttributes) {
+        this(context,null, 0, solidAttributes);
     }
 
-    public Solid(Context context, AttributeSet attrs, int defStyleAttr) {
+    /*For Android Studio Tools*/
+    private Solid(Context context){
+        super(context); }
+
+    private Solid(Context context, AttributeSet attrs, int defStyleAttr, SolidAttributes solidAttributes) {
         super(context, attrs, defStyleAttr);
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
         params.weight = 1;
         setLayoutParams(params);
+        initialize(solidAttributes);
+        setWaveColor();
     }
 
-    public void setAboveWavePaint(Paint aboveWavePaint) {
-        this.aboveWavePaint = aboveWavePaint;
+    private void initialize(SolidAttributes solidAttributes) {
+        mBackgroundDrawable = solidAttributes.getBackgroundDrawable();
+
+        mWaveColor = solidAttributes.getWaveColor();
+        mWaveAlpha = solidAttributes.getWaveAlpha();
+        setWaveAlpha(mWaveAlpha);
+        mWavePaint.setStyle(STYLE);
+        if(mBackgroundDrawable!=null) {
+            this.setBackgroundDrawable(mBackgroundDrawable);
+        }
     }
 
-    public void setBlowWavePaint(Paint blowWavePaint) {
-        this.blowWavePaint = blowWavePaint;
+    public void setWaveColor() {
+        mWavePaint.setColor(mWaveColor);
+        setWaveAlpha(mWaveAlpha);
     }
+
+    public void setWaveAlpha(float alpha){ mWavePaint.setAlpha(alphaPercentToInt(alpha)); }
+
+    public float getWaveAlpha() { return mWavePaint.getAlpha(); }
+
+    public void setWaveColor(int color) { mWavePaint.setColor(color); }
+
+    public int getWaveColor() { return mWavePaint.getColor(); }
+
+    @Override
+    public Drawable getBackground() { return mBackgroundDrawable; }
+
+    public void setBackground(Drawable backgroundDrawable){ mBackgroundDrawable = backgroundDrawable; }
 
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        canvas.drawRect(getLeft(), 0, getRight(), getBottom(), blowWavePaint);
-        canvas.drawRect(getLeft(), 0, getRight(), getBottom(), aboveWavePaint);
+        if(mBackgroundDrawable==null) {
+            canvas.drawRect(getLeft(), 0, getRight(), getBottom(), mWavePaint);
+            canvas.drawRect(getLeft(), 0, getRight(), getBottom(), mWavePaint);
+        }
     }
 }

--- a/library/src/main/java/com/john/waveview/SolidAttributes.java
+++ b/library/src/main/java/com/john/waveview/SolidAttributes.java
@@ -1,0 +1,25 @@
+package com.john.waveview;
+
+
+import android.graphics.drawable.Drawable;
+
+/**
+ * Data class to store solid attributes*/
+public class SolidAttributes {
+
+    private int mWaveColor;
+    private float mWaveAlpha;
+    private Drawable mBackgroundDrawable;
+
+    SolidAttributes(int waveColor, float waveAlpha, Drawable drawable){
+        mWaveColor = waveColor;
+        mWaveAlpha = waveAlpha;
+        mBackgroundDrawable = drawable;
+    }
+
+    public int getWaveColor() { return mWaveColor; }
+
+    public float getWaveAlpha() { return mWaveAlpha; }
+
+    public Drawable getBackgroundDrawable() { return mBackgroundDrawable; }
+}

--- a/library/src/main/java/com/john/waveview/Wave.java
+++ b/library/src/main/java/com/john/waveview/Wave.java
@@ -8,6 +8,10 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import static com.john.waveview.WaveView.LARGE;
+import static com.john.waveview.WaveView.MIDDLE;
+import static com.john.waveview.WaveView.alphaPercentToInt;
+
 // y=Asin(ωx+φ)+k
 class Wave extends View {
     private final int WAVE_HEIGHT_LARGE = 16;
@@ -22,9 +26,6 @@ class Wave extends View {
     private final float WAVE_HZ_NORMAL = 0.09f;
     private final float WAVE_HZ_SLOW = 0.05f;
 
-    public final int DEFAULT_ABOVE_WAVE_ALPHA = 50;
-    public final int DEFAULT_BLOW_WAVE_ALPHA = 30;
-
     private final float X_SPACE = 20;
     private final double PI2 = 2 * Math.PI;
 
@@ -34,14 +35,11 @@ class Wave extends View {
     private Paint mAboveWavePaint = new Paint();
     private Paint mBlowWavePaint = new Paint();
 
-    private int mAboveWaveColor;
-    private int mBlowWaveColor;
-
-    private float mWaveMultiple;
     private float mWaveLength;
-    private int mWaveHeight;
     private float mMaxRight;
     private float mWaveHz;
+    private int mWaveHeight;
+    private float mWaveMultiple;
 
     // wave animation
     private float mAboveOffset = 0.0f;
@@ -53,65 +51,56 @@ class Wave extends View {
     // ω
     private double omega;
 
-    public Wave(Context context, AttributeSet attrs) {
-        this(context, attrs, R.attr.waveViewStyle);
+    private int mAboveWaveColor;
+    private int mBlowWaveColor;
+    private float mBlowWaveAlpha;
+    private float mAboveWaveAlpha;
+
+
+    public Wave(Context context, WaveAttributes waveAttributes) {
+        this(context, null, R.attr.waveViewStyle, waveAttributes);
     }
 
-    public Wave(Context context, AttributeSet attrs, int defStyle) {
+    /*For Android Studio Tools*/
+    private Wave(Context context){
+        super(context); }
+
+    private Wave(Context context, AttributeSet attrs, int defStyle, WaveAttributes waveAttributes) {
         super(context, attrs, defStyle);
+        initializeWave(waveAttributes);
     }
 
-    @Override
-    protected void onDraw(Canvas canvas) {
-        super.onDraw(canvas);
-
-        canvas.drawPath(mBlowWavePath, mBlowWavePaint);
-        canvas.drawPath(mAboveWavePath, mAboveWavePaint);
-    }
+    public int getAboveWaveColor() { return mAboveWaveColor; }
 
     public void setAboveWaveColor(int aboveWaveColor) {
-        this.mAboveWaveColor = aboveWaveColor;
+        mAboveWavePaint.setColor(aboveWaveColor);
+        setAboveWaveAlpha(mAboveWaveAlpha);
     }
 
     public void setBlowWaveColor(int blowWaveColor) {
-        this.mBlowWaveColor = blowWaveColor;
+        mBlowWavePaint.setColor(blowWaveColor);
+        setBlowWaveAlpha(mBlowWaveAlpha);
     }
 
-    public Paint getAboveWavePaint() {
-        return mAboveWavePaint;
-    }
+    public int getBlowWaveColor() { return  mBlowWaveColor;}
 
-    public Paint getBlowWavePaint() {
-        return mBlowWavePaint;
-    }
+    public void setAboveWaveAlpha(float aboveWaveAlpha) { mAboveWavePaint.setAlpha(alphaPercentToInt(aboveWaveAlpha)); }
 
-    public void initializeWaveSize(int waveMultiple, int waveHeight, int waveHz) {
-        mWaveMultiple = getWaveMultiple(waveMultiple);
-        mWaveHeight = getWaveHeight(waveHeight);
-        mWaveHz = getWaveHz(waveHz);
-        mBlowOffset = mWaveHeight * 0.4f;
-        ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                mWaveHeight * 2);
-        setLayoutParams(params);
-    }
+    public void setBlowWaveAlpha(float blowWaveAlpha) { mBlowWavePaint.setAlpha(alphaPercentToInt(blowWaveAlpha)); }
 
-    public void initializePainters() {
-        mAboveWavePaint.setColor(mAboveWaveColor);
-        mAboveWavePaint.setAlpha(DEFAULT_ABOVE_WAVE_ALPHA);
-        mAboveWavePaint.setStyle(Paint.Style.FILL);
-        mAboveWavePaint.setAntiAlias(true);
+    public void setWaveHz(float waveHz){ mWaveHz = waveHz; }
 
-        mBlowWavePaint.setColor(mBlowWaveColor);
-        mBlowWavePaint.setAlpha(DEFAULT_BLOW_WAVE_ALPHA);
-        mBlowWavePaint.setStyle(Paint.Style.FILL);
-        mBlowWavePaint.setAntiAlias(true);
-    }
+    public float getBlowWaveColorAlpha() { return mBlowWaveAlpha; }
+
+    public float getAboveColorAlpha() { return mAboveWaveAlpha; }
+
+    public float getWaveHz() { return mWaveHz; }
 
     private float getWaveMultiple(int size) {
         switch (size) {
-            case WaveView.LARGE:
+            case LARGE:
                 return WAVE_LENGTH_MULTIPLE_LARGE;
-            case WaveView.MIDDLE:
+            case MIDDLE:
                 return WAVE_LENGTH_MULTIPLE_MIDDLE;
             case WaveView.LITTLE:
                 return WAVE_LENGTH_MULTIPLE_LITTLE;
@@ -121,9 +110,9 @@ class Wave extends View {
 
     private int getWaveHeight(int size) {
         switch (size) {
-            case WaveView.LARGE:
+            case LARGE:
                 return WAVE_HEIGHT_LARGE;
-            case WaveView.MIDDLE:
+            case MIDDLE:
                 return WAVE_HEIGHT_MIDDLE;
             case WaveView.LITTLE:
                 return WAVE_HEIGHT_LITTLE;
@@ -133,14 +122,59 @@ class Wave extends View {
 
     private float getWaveHz(int size) {
         switch (size) {
-            case WaveView.LARGE:
+            case LARGE:
                 return WAVE_HZ_FAST;
-            case WaveView.MIDDLE:
+            case MIDDLE:
                 return WAVE_HZ_NORMAL;
             case WaveView.LITTLE:
                 return WAVE_HZ_SLOW;
         }
         return 0;
+    }
+
+    private void initializeWave(WaveAttributes waveAttributes) {
+        mAboveWaveColor = waveAttributes.getAboveWaveColor();
+        mAboveWaveAlpha = waveAttributes.getAboveWaveAlpha();
+        mBlowWaveColor = waveAttributes.getBlowWaveColor();
+        mBlowWaveAlpha = waveAttributes.getBlowWaveAlpha();
+        int waveLength = waveAttributes.getWaveLength();
+        int waveHeight = waveAttributes.getWaveHeight();
+        int waveHz = waveAttributes.getWaveHz();
+        initializeWaveSize(waveLength, waveHeight, waveHz);
+        initializeAboveWaveColorAlpha();
+        initializeBlowWaveColorAlpha();
+        initializePainters();
+    }
+
+    private void initializeWaveSize(int waveMultiple, int waveHeight, int waveHz) {
+        mWaveMultiple = getWaveMultiple(waveMultiple);
+        mWaveHeight = getWaveHeight(waveHeight);
+        mWaveHz = getWaveHz(waveHz);
+        mBlowOffset = mWaveHeight * 0.4f;
+        ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, mWaveHeight * 2);
+        setLayoutParams(params);
+    }
+
+    private void initializePainters() {
+        mAboveWavePaint.setColor(mAboveWaveColor);
+        mAboveWavePaint.setAlpha(alphaPercentToInt(mAboveWaveAlpha));
+        mAboveWavePaint.setStyle(Paint.Style.FILL);
+        mAboveWavePaint.setAntiAlias(true);
+
+        mBlowWavePaint.setColor(mBlowWaveColor);
+        mBlowWavePaint.setAlpha(alphaPercentToInt(mBlowWaveAlpha));
+        mBlowWavePaint.setStyle(Paint.Style.FILL);
+        mBlowWavePaint.setAntiAlias(true);
+    }
+
+    private void initializeAboveWaveColorAlpha() {
+        setAboveWaveAlpha(mAboveWaveAlpha);
+        setAboveWaveColor(mAboveWaveColor);
+    }
+
+    private void initializeBlowWaveColorAlpha() {
+        setBlowWaveAlpha(mBlowWaveAlpha);
+        setBlowWaveColor(mBlowWaveColor);
     }
 
     /**
@@ -166,6 +200,13 @@ class Wave extends View {
             mBlowWavePath.lineTo(x, y);
         }
         mBlowWavePath.lineTo(right, bottom);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        canvas.drawPath(mBlowWavePath, mBlowWavePaint);
+        canvas.drawPath(mAboveWavePath, mAboveWavePaint);
     }
 
     @Override

--- a/library/src/main/java/com/john/waveview/WaveAttributes.java
+++ b/library/src/main/java/com/john/waveview/WaveAttributes.java
@@ -1,0 +1,46 @@
+package com.john.waveview;
+
+/**
+ * Data class to store wave attributes*/
+public class WaveAttributes {
+
+    private int mAboveWaveColor;
+    private float mAboveWaveAlpha;
+    private int mBlowWaveColor;
+    private float mBlowWaveAlpha;
+    private int mWaveLength;
+    private int mWaveHeight;
+    private int mWaveHz;
+
+    WaveAttributes(
+            int aboveWaveColor,
+            float aboveWaveAlpha,
+            int blowWaveColor,
+            float blowWaveAlpha,
+            int waveLength,
+            int waveHz,
+            int waveHeight){
+        mAboveWaveAlpha = aboveWaveAlpha;
+        mAboveWaveColor = aboveWaveColor;
+        mBlowWaveAlpha = blowWaveAlpha;
+        mBlowWaveColor = blowWaveColor;
+        mWaveLength = waveLength;
+        mWaveHz = waveHz;
+        mWaveHeight = waveHeight;
+    }
+
+    public int getAboveWaveColor() { return mAboveWaveColor; }
+
+    public int getBlowWaveColor() { return mBlowWaveColor; }
+
+    public float getBlowWaveAlpha() { return mBlowWaveAlpha; }
+
+    public float getAboveWaveAlpha() { return mAboveWaveAlpha; }
+
+    public int getWaveLength() { return mWaveLength; }
+
+    public int getWaveHeight() { return mWaveHeight; }
+
+    public int getWaveHz() { return mWaveHz; }
+
+}

--- a/library/src/main/res/values/attr.xml
+++ b/library/src/main/res/values/attr.xml
@@ -3,7 +3,11 @@
 
 	<declare-styleable name="WaveView">
 		<attr name="above_wave_color" format="color"/>
+        <attr name="above_wave_color_alpha" format="float"/>
+
 		<attr name="blow_wave_color" format="color"/>
+        <attr name="blow_wave_color_alpha" format="float"/>
+
 		<attr name="progress" format="integer"/>
         <attr name="wave_length" format="enum">
             <enum name="large" value="1"/>
@@ -20,6 +24,11 @@
             <enum name="normal" value="2"/>
             <enum name="slow" value="3"/>
         </attr>
+
+        <attr name="wave_color" format="color"/>
+        <attr name="wave_alpha" format="float"/>
+
+        <attr name="background" format="reference"/>
 	</declare-styleable>
 
 	<declare-styleable name="Themes">


### PR DESCRIPTION
- Users can apply background color, wave filling's color and alpha declaratively (XML) or programatically. [#6,#23]
<p align="center">
<img src="https://user-images.githubusercontent.com/44941115/108837541-56eda780-760d-11eb-8fa7-e1536f87731c.gif" width="25%" height="25%" /> 

<img src="https://user-images.githubusercontent.com/44941115/108838109-28bc9780-760e-11eb-9670-696078ba268b.gif" width="25%" height="25%" /> 
</p> 

- Users can alter above and below wave's color and alpha. [#23]


```
<com.john.waveview.WaveView
        android:id="@+id/wave_view"
        android:layout_width="match_parent"
        android:layout_height="match_parent"
        android:background="#FFFFFF"
        wave:above_wave_color="@color/dark_blue"
        wave:blow_wave_color="@color/light_blue"
        wave:above_wave_color_alpha="0.5"
        wave:blow_wave_color_alpha="0.3"
        wave:progress="80"
        wave:wave_height="large"
        wave:wave_hz="normal"
        wave:wave_length="middle" 
        wave:wave_color="@color/holo_purple"
        wave:wave_alpha="0.5"/>
```  

```
        waveView.setAboveWaveColor(color);
        waveView.setBlowWaveColor(color);
        waveView.setWaveColor(color);
        waveView.setWaveAlpha(0.5f);
        waveView.setAboveWaveColorAlpha(0.3f);
        waveView.setBlowWaveColorAlpha(0.3f);
```
        
- Made default above and below wave color to be that of the actual wave color, instead of white color.
- Users can make the wave color to be their gradient color. [#24]

<p align="center">
<img src="https://user-images.githubusercontent.com/44941115/108838283-67eae880-760e-11eb-94e2-1015a0b221a0.gif" width="25%" height="25%" /> 
</p>

```
....
wave:background="@drawable/gradient_background"/>
```
 `waveView.setWaveBackgroundDrawable(getResources().getDrawable(R.drawable.gradient_background));`